### PR TITLE
[dep] Upgrade to datadog-ci `v1.4.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ orbs:
 
 jobs:
   e2e-tests:
-    docker: 
+    docker:
       - image: cimg/base:stable
     steps:
       - synthetics-ci/run-tests:
@@ -51,7 +51,7 @@ orbs:
 
 jobs:
   e2e-tests:
-    docker: 
+    docker:
       - image: cimg/base:stable
     steps:
       - synthetics-ci/run-tests:
@@ -75,7 +75,7 @@ orbs:
 
 jobs:
   e2e-tests:
-    docker: 
+    docker:
       - image: cimg/base:stable
     steps:
       - synthetics-ci/run-tests:
@@ -138,7 +138,7 @@ Name | Type | Default | Description
 `test_search_query` | string | _none_ | Trigger tests corresponding to a search query.
 `tunnel` | boolean | `false` | Use the testing tunnel to trigger tests.
 `variables` | string | _none_ | Key-value pairs for injecting variables into tests. Must be formatted using `KEY=VALUE`.
-`version` | string | `v1.1.1` | The version of `datadog-ci` to use.
+`version` | string | `v1.4.0` | The version of `datadog-ci` to use.
 
 ## Further Reading
 
@@ -160,4 +160,4 @@ Additional helpful documentation, links, and articles:
 [9]: https://discuss.circleci.com/c/orbs
 [10]: https://docs.datadoghq.com/synthetics/testing_tunnel
 [11]: https://docs.datadoghq.com/synthetics/cicd_integrations/github_actions
-[12]: https://docs.datadoghq.com/synthetics/cicd_integrations/configuration?tab=npm  
+[12]: https://docs.datadoghq.com/synthetics/cicd_integrations/configuration?tab=npm

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -56,7 +56,7 @@ parameters:
   version:
     type: string
     description: Version of datadog-ci.
-    default: "v1.1.1"
+    default: "v1.4.0"
 steps:
   - run:
       environment:

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -7,7 +7,7 @@ RunTests() {
     fi
 
     curl -L --fail "https://github.com/DataDog/datadog-ci/releases/download/${PARAM_VERSION}/datadog-ci_linux-x64" --output "./datadog-ci"
-    
+
     chmod +x ./datadog-ci
 
     # Only used for unit test purposes
@@ -63,6 +63,7 @@ RunTests() {
     DATADOG_APP_KEY="${PARAM_APP_KEY}" \
     DATADOG_SUBDOMAIN="${PARAM_SUBDOMAIN}" \
     DATADOG_SITE="${PARAM_SITE}" \
+    DATADOG_SYNTHETICS_CI_TRIGGER_APP="circle_ci_orb" \
         $DATADOG_CI_COMMAND synthetics run-tests \
         "${args[@]}"
 }

--- a/src/tests/run-tests.bats
+++ b/src/tests/run-tests.bats
@@ -16,11 +16,11 @@ setup() {
     export PARAM_SUBDOMAIN="app1"
     export PARAM_TEST_SEARCH_QUERY="apm"
     export PARAM_TUNNEL="1"
-    export PARAM_VERSION="v1.1.1"
+    export PARAM_VERSION="v1.4.0"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)
-    
+
     if ! echo $result | grep -q "synthetics run-tests --failOnTimeout --tunnel --config ./some/other/path.json --files test1.json --public-id jak-not-now --public-id jak-one-mor --search apm"
     then
       echo $result
@@ -41,7 +41,7 @@ setup() {
     export PARAM_SUBDOMAIN=""
     export PARAM_TEST_SEARCH_QUERY=""
     export PARAM_TUNNEL="0"
-    export PARAM_VERSION="v1.1.1"
+    export PARAM_VERSION="v1.4.0"
     export DATADOG_CI_COMMAND="echo"
 
     result=$(RunTests)


### PR DESCRIPTION
Upgrade default version to [datadog-ci `v1.4.0`](https://github.com/DataDog/datadog-ci/releases/tag/v1.4.0), set trigger app through environment variable.

No doc change.